### PR TITLE
Rework settings to use an external file

### DIFF
--- a/MFN.Settings.xml
+++ b/MFN.Settings.xml
@@ -1,3 +1,29 @@
 <Settings>
-    <!-- TODO implement -->
+    <Setting Id="Door"  Label="Door Splitter - Splits On EVERY Door" />
+    <Setting Id="DoorC" Label="Custom Door Splitter - Only Splits Once On Area">
+        <Setting Id="Pearl's Rolodexer Room" Label="Rolodexer Room (Handgun Room)" />
+        <Setting Id="Pearl's Sound Stage" Label="Sound Stage (Town Square)" />
+        <Setting Id="Pearl's Sound Stage-MainBuildingInside" Label="Stage Main Building (Middle Building)" />
+        <Setting Id="RaysMainAtrium" Label="Underground Atrium" />
+        <Setting Id="RaysFixinsRoom" Label="Fixins Room (Power Source)" />
+        <Setting Id="Ray'sDocks4" Label="Dock 4" />
+        <Setting Id="Ray'sDocks2" Label="Dock 2 (Boltcutters)" />
+        <Setting Id="GobblesOfficesEntrance" Label="Office Entrance" />
+        <Setting Id="Gobbles Projection Room2" Label="Theater Room" />
+        <Setting Id="Gobbles Studio" Label="Studio (Game Piece)" />
+        <Setting Id="Gobbles Bare Room Offices" Label="Bare Room Office (Angry Mask)" />
+        <Setting Id="Gobbles Art Storage" Label="Art Storage" />
+        <Setting Id="Gobbles Elevator Maintenance" Label="Elevator Maintenence Room" />
+        <Setting Id="GobblesOfficesEntrance-CEOOffice" Label="CEO Office" />
+        <Setting Id="Exterior-HedgeMaze" Label="Garden Maze" />
+        <Setting Id="Exterior-GreenhouseInterior" Label="Greenhouse Interior" />
+        <Setting Id="Gobbles Sound Studio" Label="Sound Studio" />
+        <Setting Id="RaysFilmArchives" Label="Film Archives" />
+        <Setting Id="PenthouseEntrance" Label="Penthouse Entrance" />
+        <Setting Id="Elmer's Two Side Room" Label="Hexagonal Key Room" />
+        <Setting Id="PenthouseBackHall2" Label="Penthouse Art Hall" />
+        <Setting Id="Exterior-Antenna" Label="Roof" />
+        <Setting Id="Unfriendly Neighborhood Proper" Label="Unfriendly Neighbourhood Arena" />
+    </Setting>
+    <Setting Id="Final" Label="Final Split - Always Active" State="true" />
 </Settings>

--- a/MFN.Settings.xml
+++ b/MFN.Settings.xml
@@ -1,29 +1,29 @@
 <Settings>
-    <Setting Id="Door"  Label="Door Splitter - Splits On EVERY Door" />
+    <Setting Id="Door"  Label="Door Splitter - Splits On EVERY Door" State="false" />
     <Setting Id="DoorC" Label="Custom Door Splitter - Only Splits Once On Area">
-        <Setting Id="Pearl's Rolodexer Room" Label="Rolodexer Room (Handgun Room)" />
-        <Setting Id="Pearl's Sound Stage" Label="Sound Stage (Town Square)" />
-        <Setting Id="Pearl's Sound Stage-MainBuildingInside" Label="Stage Main Building (Middle Building)" />
-        <Setting Id="RaysMainAtrium" Label="Underground Atrium" />
-        <Setting Id="RaysFixinsRoom" Label="Fixins Room (Power Source)" />
-        <Setting Id="Ray'sDocks4" Label="Dock 4" />
-        <Setting Id="Ray'sDocks2" Label="Dock 2 (Boltcutters)" />
-        <Setting Id="GobblesOfficesEntrance" Label="Office Entrance" />
-        <Setting Id="Gobbles Projection Room2" Label="Theater Room" />
-        <Setting Id="Gobbles Studio" Label="Studio (Game Piece)" />
-        <Setting Id="Gobbles Bare Room Offices" Label="Bare Room Office (Angry Mask)" />
-        <Setting Id="Gobbles Art Storage" Label="Art Storage" />
-        <Setting Id="Gobbles Elevator Maintenance" Label="Elevator Maintenence Room" />
-        <Setting Id="GobblesOfficesEntrance-CEOOffice" Label="CEO Office" />
-        <Setting Id="Exterior-HedgeMaze" Label="Garden Maze" />
-        <Setting Id="Exterior-GreenhouseInterior" Label="Greenhouse Interior" />
-        <Setting Id="Gobbles Sound Studio" Label="Sound Studio" />
-        <Setting Id="RaysFilmArchives" Label="Film Archives" />
-        <Setting Id="PenthouseEntrance" Label="Penthouse Entrance" />
-        <Setting Id="Elmer's Two Side Room" Label="Hexagonal Key Room" />
-        <Setting Id="PenthouseBackHall2" Label="Penthouse Art Hall" />
-        <Setting Id="Exterior-Antenna" Label="Roof" />
-        <Setting Id="Unfriendly Neighborhood Proper" Label="Unfriendly Neighbourhood Arena" />
+        <Setting Id="Pearl's Rolodexer Room" Label="Rolodexer Room (Handgun Room)" State="false" />
+        <Setting Id="Pearl's Sound Stage" Label="Sound Stage (Town Square)" State="false" />
+        <Setting Id="Pearl's Sound Stage-MainBuildingInside" Label="Stage Main Building (Middle Building)" State="false" />
+        <Setting Id="RaysMainAtrium" Label="Underground Atrium" State="false" />
+        <Setting Id="RaysFixinsRoom" Label="Fixins Room (Power Source)" State="false" />
+        <Setting Id="Ray'sDocks4" Label="Dock 4" State="false" />
+        <Setting Id="Ray'sDocks2" Label="Dock 2 (Boltcutters)" State="false" />
+        <Setting Id="GobblesOfficesEntrance" Label="Office Entrance" State="false" />
+        <Setting Id="Gobbles Projection Room2" Label="Theater Room" State="false" />
+        <Setting Id="Gobbles Studio" Label="Studio (Game Piece)" State="false" />
+        <Setting Id="Gobbles Bare Room Offices" Label="Bare Room Office (Angry Mask)" State="false" />
+        <Setting Id="Gobbles Art Storage" Label="Art Storage" State="false" />
+        <Setting Id="Gobbles Elevator Maintenance" Label="Elevator Maintenence Room" State="false" />
+        <Setting Id="GobblesOfficesEntrance-CEOOffice" Label="CEO Office" State="false" />
+        <Setting Id="Exterior-HedgeMaze" Label="Garden Maze" State="false" />
+        <Setting Id="Exterior-GreenhouseInterior" Label="Greenhouse Interior" State="false" />
+        <Setting Id="Gobbles Sound Studio" Label="Sound Studio" State="false" />
+        <Setting Id="RaysFilmArchives" Label="Film Archives" State="false" />
+        <Setting Id="PenthouseEntrance" Label="Penthouse Entrance" State="false" />
+        <Setting Id="Elmer's Two Side Room" Label="Hexagonal Key Room" State="false" />
+        <Setting Id="PenthouseBackHall2" Label="Penthouse Art Hall" State="false" />
+        <Setting Id="Exterior-Antenna" Label="Roof" State="false" />
+        <Setting Id="Unfriendly Neighborhood Proper" Label="Unfriendly Neighbourhood Arena" State="false" />
     </Setting>
     <Setting Id="Final" Label="Final Split - Always Active" State="true" />
 </Settings>

--- a/My Friendly Neighborhood.asl
+++ b/My Friendly Neighborhood.asl
@@ -55,8 +55,8 @@ init
 
 update
 {
-	current.activeScene = vars.Helper.Scenes.Active.Name == null ? current.activeScene : vars.Helper.Scenes.Active.Name;		//creates a function that tracks the games active Scene name
-	current.loadingScene = vars.Helper.Scenes.Loaded[0].Name == null ? current.loadingScene : vars.Helper.Scenes.Loaded[0].Name;	//creates a function that tracks the games currently loading Scene name
+	current.activeScene = vars.Helper.Scenes.Active.Name ?? current.activeScene;
+	current.loadingScene = vars.Helper.Scenes.Loaded[0].Name ?? current.loadingScene;
 }
 
 onStart 


### PR DESCRIPTION
!!!**BEFORE MERGING you should open a PR on the autosplitters repo to add the xml to the list of URLs.**!!!

This PR:
- reworks the settings to extract them into a separate file. Makes things easier to use.
- changes the door splits to happen when the loading scene changes, rather than the active scene. This means it now splits as soon as you enter a loading screen, which is preferable.
- clears completedSplits on onStart rather than continuously in update {}. Currently it is clearing this every tick the timer isn't running, which is unnecessary.
- fixes up some formatting

Just a few notes on your implementation:
- if you want to iterate over a list, don't hardcode the list's length (23). Instead, use it's .Count property.
- If you have a string, then you don't need to convert it to a string with .ToString(). This does nothing. Additionally, doing `"" +` is also redundant. Both of these things are ways to convert something into a string, and you only need to do one of them when you don't have a string. But it is already a string.
```cs
for(int i = 0; i < vars.DoorCSplits.Count; i++) {
    settings.Add(vars.DoorCSplits[i], false, vars.DoorCSettings[i]);
}
```
- Consider using a foreach loop when you don't need the index.
```cs
foreach (var split in vars.DoorCSplits) { ... }
```
- The current.active/loadingScene = ... lines do not "create a function". It just stores the current loaded and active scene onto the current object. The conditional operator (?) just ensures we don't set this to null.
- **